### PR TITLE
Datasets and replicate

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,0 +1,7 @@
+[TestData]
+git-tree-sha1 = "9d575764bc1c1a7860c34c5b153251e5f2ee6704"
+lazy = true
+
+    [[TestData.download]]
+    sha256 = "0b63ae3e9e457ee4b33482d3bf8cc7f20c8ed7c8b2c863af311ba0944c6d46e4"
+    url = "https://ndownloader.figshare.com/files/21085968"

--- a/Project.toml
+++ b/Project.toml
@@ -5,8 +5,11 @@ version = "0.1.0"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+Feather = "becb17da-46f6-5d3c-ad1b-1c5fe96bc73c"
 MixedModels = "ff71e718-51f3-5ec2-a782-8ffcbfa3c316"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 PooledArrays = "2dfb63ee-cc39-5dd5-95bd-886bf059d720"
+ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"

--- a/Project.toml
+++ b/Project.toml
@@ -18,10 +18,12 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 [compat]
 DataFrames = "0.20"
 Documenter = "0.24"
-MixedModels = "2"
+Feather = "0.5"
+MixedModels = "≥2.2"
 PooledArrays = "0.5"
+ProgressMeter = "1.2.0"
 StaticArrays = "0.12"
-Tables = "0.2"
+Tables = "~0.2"
 julia = "1.3"
 
 [extras]

--- a/src/MMutils.jl
+++ b/src/MMutils.jl
@@ -1,0 +1,54 @@
+# this functionality is copied from the development version of MixedModels.jl
+# and should be removed when MixedModels 3.0 is released
+using ProgressMeter
+using Feather
+"""
+    replicate(f::Function, n::Integer, use_threads=false)
+
+Return a vector of the values of `n` calls to `f()` - used in simulations where the value of `f` is stochastic.
+
+Note that if `f()` is not thread-safe or depends on a non thread-safe RNG,
+    then you must set `use_threads=false`. Also note that ordering of replications
+    is not guaranteed when `use_threads=true`, although the replications are not
+    otherwise affected for thread-safe `f()`.
+"""
+function replicate(f::Function, n::Integer; use_threads=false)
+    if use_threads
+        # no macro version yet: https://github.com/timholy/ProgressMeter.jl/issues/143
+        p = Progress(n)
+        # get the type
+        rr = f()
+        next!(p)
+        # pre-allocate
+        results = [rr for _ in Base.OneTo(n)]
+        Threads.@threads for idx = 2:n
+            results[idx] = f()
+            next!(p)
+        end
+    else
+        results = @showprogress [f() for _ in Base.OneTo(n)]
+    end
+    results
+end
+
+"""
+    dataset(nm)
+
+Return the data frame of test data set named `nm`, which can be a `String` or `Symbol`
+"""
+function dataset(nm::AbstractString)
+    path = joinpath(TestData, nm * ".feather")
+    if !isfile(path)
+        throw(ArgumentError(
+            "Dataset \"$nm\" is not available.\nUse MixedModels.datasets() for available names."))
+    end
+    Feather.read(path)
+end
+dataset(nm::Symbol) = dataset(string(nm))
+
+"""
+    datasets()
+
+Return a vector of names of the available test data sets
+"""
+datasets() = first.(Base.Filesystem.splitext.(filter(Base.Fix2(endswith, ".feather"), readdir(TestData))))

--- a/src/MixedModelsSim.jl
+++ b/src/MixedModelsSim.jl
@@ -1,6 +1,10 @@
 module MixedModelsSim
 
-using DataFrames, PooledArrays, Tables, Statistics
+using DataFrames
+using PooledArrays
+using Tables
+using Statistics
+using Pkg.Artifacts
 
 export
     cyclicshift,
@@ -14,6 +18,11 @@ export
     sim_to_df,
     simdat_crossed
 
+function __init__()
+    global TestData = artifact"TestData"
+end
+
+include("MMutils.jl")
 include("columntable.jl")
 include("power.jl")
 include("simdat.jl")

--- a/src/power.jl
+++ b/src/power.jl
@@ -28,7 +28,7 @@ Note that this functionality depends on the development version
 using MixedModels, MixedModelsSim
 using DataFrames, Gadfly, Random, StaticArrays, StatsBase, Tables
 
-kb07 = MixedModels.dataset(:kb07);
+kb07 = MixedModelsSim.dataset(:kb07);
 form = @formula(rt_raw ~ 1 + spkr + prec + load + (1+spkr+prec+load|subj) + (1+spkr+prec+load|item));
 cont = Dict(:spkr => HelmertCoding(),
             :prec => HelmertCoding(),

--- a/src/power.jl
+++ b/src/power.jl
@@ -83,6 +83,7 @@ function simulate_waldtests(
         mod = simulate!(rng, mod, β = β, σ = σ, θ = θ)
         unlock(rnglock)
         refit!(mod)
+        @info objective(mod)
         ct = coeftable(mod)
         names = Tuple(Symbol.(ct.rownms))
         (

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 MixedModels = "ff71e718-51f3-5ec2-a782-8ffcbfa3c316"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
@@ -7,4 +8,4 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-Tables = "0.2"
+Documenter = "0.24"

--- a/test/power.jl
+++ b/test/power.jl
@@ -12,7 +12,7 @@ using Test
 	            :prec => HelmertCoding(),
 	            :load => HelmertCoding())
 	fm1 = fit(MixedModel, form, kb07, contrasts=cont, REML=false);
-	zpmt = simulate_waldtests(MersenneTwister(42),10,fm1,use_threads=true);
+	zpmt = simulate_waldtests(MersenneTwister(42),10,fm1,use_threads=false);
 	pvals = getindex.(columntable(zpmt).p,1)
 	power = sum(pvals .< 0.05) / length(pvals)
 	@test power == 1.

--- a/test/power.jl
+++ b/test/power.jl
@@ -6,7 +6,7 @@ using Test
 
 
 @testset "powersimulation" begin
-	kb07 = MixedModels.dataset(:kb07);
+	kb07 = MixedModelsSim.dataset(:kb07);
 	form = @formula(rt_raw ~ 1 + spkr + prec + load + (1+spkr+prec+load|subj) + (1+spkr+prec+load|item));
 	cont = Dict(:spkr => HelmertCoding(),
 	            :prec => HelmertCoding(),

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,4 @@
+using Documenter
 using MixedModelsSim
 using Test
 

--- a/test/sim.jl
+++ b/test/sim.jl
@@ -3,7 +3,7 @@ using DataFrames, Tables
 using Statistics
 using Test
 
-kb07 = MixedModels.dataset(:kb07);
+kb07 = MixedModelsSim.dataset(:kb07);
 form = @formula(rt_raw ~ 1 + spkr + prec + load + (1+spkr+prec+load|subj) + (1+spkr+prec+load|item));
 cont = Dict(:spkr => HelmertCoding(),
             :prec => HelmertCoding(),


### PR DESCRIPTION
Lots of formalities making preparing for a proper release. I've reimplemented some functionality from the development version of MixedModels to allow compatibility with the current release (v2.2.0). Because of the way package artifacts are cached, we also don't incur an additional storage penalty for the user.

Closes #8, closes #9 .