### PR TITLE
Return a RowTable from simulate_waldtests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 MixedModels = "ff71e718-51f3-5ec2-a782-8ffcbfa3c316"
 PooledArrays = "2dfb63ee-cc39-5dd5-95bd-886bf059d720"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
@@ -14,11 +15,11 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
 DataFrames = "0.20"
-Documenter = "0.24"
-MixedModels = "2"
+Distributions = "0.22"
+Documenter = "0.23"
 PooledArrays = "0.5"
 StaticArrays = "0.12"
-Tables = "0.2"
+Tables = "1"
 julia = "1.3"
 
 [extras]

--- a/src/MixedModelsSim.jl
+++ b/src/MixedModelsSim.jl
@@ -2,20 +2,20 @@ module MixedModelsSim
 
 using DataFrames
 using Distributions: Chisq, ccdf
+using MixedModels
 using PooledArrays
+using Random
 using Tables
 using Statistics
 
 export
     cyclicshift,
     factorproduct,
-    itemsubjdf,
     nlevels,
     pooled!,
     simulate_waldtests,
     withinitem,
     power_table,
-    sim_to_df,
     simdat_crossed
 
 include("columntable.jl")

--- a/src/MixedModelsSim.jl
+++ b/src/MixedModelsSim.jl
@@ -1,6 +1,10 @@
 module MixedModelsSim
 
-using DataFrames, PooledArrays, Tables, Statistics
+using DataFrames
+using Distributions: Chisq, ccdf
+using PooledArrays
+using Tables
+using Statistics
 
 export
     cyclicshift,

--- a/src/simdat.jl
+++ b/src/simdat.jl
@@ -97,7 +97,6 @@ Rows are all the coefficients for each iteration of `sim`, the output of `simula
 `iteration` is not guaranteed to be the same across runs of `simulate_waldtests` with the same seed, 
 even though the samples will be.
 """
-
 function sim_to_df(sims)
     tab = DataFrame()
     for (i, sim) in enumerate(sims)

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -7,4 +7,4 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-Tables = "0.2"
+Tables = "1"


### PR DESCRIPTION
A `RowTable` can be directly converted to a `DataFrame` which can be used in calls to `by` and to `Gadfly::plot`.  See the example in the documentation for `simulate_waldtests`.

Right now this branch requires the `fixef!` branch of `MixedModels` because it uses `MixedModels.stderror!`