### PR TITLE
Add nlevstbl, clean up dependencies

### DIFF
--- a/.github/workflows/Tier2.yml
+++ b/.github/workflows/Tier2.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        julia-version: [1.5, nightly]
+        julia-version: [1.5] #, nightly]
         julia-arch: [x64, x86]
         os: [ubuntu-18.04, macos-10.15, windows-2019]
         exclude:

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ authors = ["Phillip Alday", "Douglas Bates", "Lisa DeBruine", "Reinhold Kliegl"]
 version = "0.2.2"
 
 [deps]
-Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MixedModels = "ff71e718-51f3-5ec2-a782-8ffcbfa3c316"
 PooledArrays = "2dfb63ee-cc39-5dd5-95bd-886bf059d720"
@@ -14,10 +13,10 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
-Documenter = "0.23, 0.24, 0.25, 0.26"
+Documenter = "0.25, 0.26"
 MixedModels = "3"
-PooledArrays = "0.5, 1.0"
-PrettyTables = "0.11, 0.12, 1.0"
+PooledArrays = "0.5, 1"
+PrettyTables = "0.12, 1"
 Tables = "1.0"
 julia = "1.3"
 

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,10 +1,8 @@
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-Gadfly = "c91e804a-d5a3-530f-b6f0-dfbca275c004"
 MixedModels = "ff71e718-51f3-5ec2-a782-8ffcbfa3c316"
 MixedModelsSim = "d5ae56c5-23ca-4a1f-b505-9fc4796fc1fe"
-Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
 Documenter = "0.26"

--- a/src/MixedModelsSim.jl
+++ b/src/MixedModelsSim.jl
@@ -16,6 +16,7 @@ export
     factorproduct,
     flatlowertri,
     nlevels,
+    nlevstbl,
     #withinitem,
     pooled!,
     power_table,

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -78,12 +78,45 @@ function nlevels(nlev, tag='S')
 end
 
 """
+    nlevstbl(nm::Symbol, n, vars::Pair{Symbol, Vector{String}}...)
+
+Return a `Tables.columntable` with a `nm` column as a `PooledArray` with `n` levels.
+
+If any `vars` pairs are given they are expanded to columns representing characteristics
+of the `nm` column.  In experimental design terminology, if say `nm` is `:item` then these
+represent between-item experimental factors.
+
+The `nm` column is generated as `nlevels(n, uppercase(first(string(nm))))`
+
+# Examples
+```julia-repl
+julia> nlevstbl(:item, 10)
+(item = ["I01", "I02", "I03", "I04", "I05", "I06", "I07", "I08", "I09", "I10"],)
+
+julia> nlevstbl(:item, 9, :level => ["low", "medium", "high"])
+(item = ["I1", "I2", "I3", "I4", "I5", "I6", "I7", "I8", "I9"], level = ["low", "medium", "high", "low", "medium", "high", "low", "medium", "high"])
+```
+"""
+function nlevstbl(nm::Symbol, n::Integer, vars::Pair{Symbol, Vector{String}}...)
+    nms = [nm]
+    vals = [PooledArray(nlevels(n, uppercase(first(string(nm)))), signed=true, compress=true)]
+    for var in vars
+        levs = last(var)
+        q, r = divrem(n, length(levs))
+        iszero(r) || throw(ArgumentError("n = $n is not a multiple of length($levs)"))
+        push!(vals, PooledArray(repeat(levs, outer=q), signed=true, compress=true))
+        push!(nms, first(var))
+    end
+    NamedTuple{(nms...,)}((vals...,))
+end
+
+"""
     pooled!(df, cols::Type=Union{AbstractString,Missing})
 
 Like `DataFrames.categorical!` but converting columns to `PooledArray`s
 
 !!! warning
-    This method is not type-specific in the first argument order to eliminate
+    This method is not type-specific in the first argument, in order to eliminate
     a dependency on `DataFrames.jl`. It nonetheless expects a `DataFrame` as
     its first argument
 """

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -100,12 +100,16 @@ julia> nlevstbl(:item, 9, :level => ["low", "medium", "high"])
 function nlevstbl(nm::Symbol, n::Integer, vars::Pair{Symbol, Vector{String}}...)
     nms = [nm]
     vals = [PooledArray(nlevels(n, uppercase(first(string(nm)))), signed=true, compress=true)]
+    inner = 1
     for var in vars
         levs = last(var)
-        q, r = divrem(n, length(levs))
-        iszero(r) || throw(ArgumentError("n = $n is not a multiple of length($levs)"))
-        push!(vals, PooledArray(repeat(levs, outer=q), signed=true, compress=true))
+        nlev = length(levs)
+        rept = inner * nlev
+        q, r = divrem(n, rept)
+        iszero(r) || throw(ArgumentError("n = $n is not a multiple of repetition block size $rept"))
+        push!(vals, PooledArray(repeat(levs, inner=inner, outer=q), signed=true, compress=true))
         push!(nms, first(var))
+        inner = rept
     end
     NamedTuple{(nms...,)}((vals...,))
 end

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -20,6 +20,21 @@ end
     @test first(levs) == "k001"
 end
 
+@testset "nlevstbl" begin
+    subj = DataFrame(nlevstbl(:subj, 20))
+    @test nrow(subj) == 20
+    @test isone(ncol(subj))
+    @test propertynames(subj) == [:subj]
+    item = DataFrame(nlevstbl(:item, 9, :lev => ["low", "medium", "high"]))
+    @test nrow(item) == 9
+    @test ncol(item) == 2
+    @test propertynames(item) == [:item, :lev]
+    @test first(first(subj)) == "S01"
+    df = crossjoin(subj, item)
+    @test nrow(df) == 180
+    @test ncol(df) == 3
+end
+
 @testset "pooled!" begin
     subject = (subj = ["S1","S2","S3","S4","S5"], age=["O","O","O","Y","Y"]);
 

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -34,6 +34,10 @@ end
     @test nrow(df) == 180
     @test ncol(df) == 3
     @test_throws ArgumentError nlevstbl(:baditem, 9, :nlev => ["low", "high"])
+    twofac = nlevstbl(:item, 18, :level => ["low", "medium", "high"], :blur => ["N", "Y"])
+    @test length(twofac) == 3
+    @test length(first(twofac)) == 18
+    @test_throws ArgumentError nlevstbl(:item, 18, :level => ["low", "high"], :blur => ["N", "Y"])
 end
 
 @testset "pooled!" begin

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -33,6 +33,7 @@ end
     df = crossjoin(subj, item)
     @test nrow(df) == 180
     @test ncol(df) == 3
+    @test_throws ArgumentError nlevstbl(:baditem, 9, :nlev => ["low", "high"])
 end
 
 @testset "pooled!" begin


### PR DESCRIPTION
The `nlevstbl` methods produce a `Tables.columntable` from a name for the grouping factor and the number of levels.  Optional between-level columns can also be generated.

Combining this with `DataFrames` and `crossjoin` can make generation of designs with crossed grouping factors somewhat cleaner.
```julia
julia> df = crossjoin(DataFrame(nlevstbl(:subj, 20)), DataFrame(nlevstbl(:item, 9, :lev => ["low","medium", "high"])))
180×3 DataFrame
 Row │ subj    item    lev    
     │ String  String  String 
─────┼────────────────────────
   1 │ S01     I1      low
   2 │ S01     I2      medium
   3 │ S01     I3      high
   4 │ S01     I4      low
   5 │ S01     I5      medium
   6 │ S01     I6      high
   7 │ S01     I7      low
   8 │ S01     I8      medium
   9 │ S01     I9      high
  10 │ S02     I1      low
  11 │ S02     I2      medium
  ⋮  │   ⋮       ⋮       ⋮
 170 │ S19     I8      medium
 171 │ S19     I9      high
 172 │ S20     I1      low
 173 │ S20     I2      medium
 174 │ S20     I3      high
 175 │ S20     I4      low
 176 │ S20     I5      medium
 177 │ S20     I6      high
 178 │ S20     I7      low
 179 │ S20     I8      medium
 180 │ S20     I9      high
              158 rows omitted
```