### PR TITLE
bump PrettyTables compat to 2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,6 +15,6 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 [compat]
 MixedModels = "4"
 PooledArrays = "0.5, 1"
-PrettyTables = "0.11, 0.12, 1"
+PrettyTables = "0.11, 0.12, 1, 2"
 Tables = "1.0"
 julia = "1.3"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MixedModelsSim"
 uuid = "d5ae56c5-23ca-4a1f-b505-9fc4796fc1fe"
 authors = ["Phillip Alday", "Douglas Bates", "Lisa DeBruine", "Reinhold Kliegl"]
-version = "0.2.6"
+version = "0.2.7"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"


### PR DESCRIPTION
PrettyTables v2.0 was released 3 months ago with breaking changes to API and visuals. MixedModelsSim seems to depend on PrettyTables just to re-export `pretty_table()`/`@pt` for convenience, and testing the build with PrettyTables > v2.0 didn't lead to any changes in behavior (makes sense). Additionally, where `pretty_table()` *is* used in the docs, it's just printing rowtables in MIME, so there's no visual change there either (breaking changes were about rendering to HTML).

The PR just extends compat for PrettyTables v2.0, which, among other things, resolves conflict with DataFrames >= 1.4.0 (which dropped compat for v1.0 and bumped to v2.1).

Thanks!